### PR TITLE
Migrate from custom socket proto to http

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,21 +1,22 @@
 package server
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
-	"strconv"
+	"time"
 )
 
 type Server struct {
-	path   string
-	logger *log.Logger
+	path       string
+	logger     *log.Logger
+	httpServer *http.Server
 }
 
 type Command struct {
@@ -27,108 +28,74 @@ func UnixSocketPath() string {
 	return os.TempDir() + "rdm.sock"
 }
 
-func (s *Server) Listen(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	sock, err := net.Listen("unix", s.path)
-
+func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		return err
+		log.Printf("could not read request body: %v", err)
 	}
-	defer sock.Close()
+	r.Body.Close()
+
+	var command Command
+	json.Unmarshal(body, &command)
+
+	switch command.Name {
+	case "copy":
+		err := copy(command.Arguments[0])
+		if err != nil {
+			log.Printf("error running copy command: %v", err)
+		}
+	case "open":
+		err := open(command.Arguments[0])
+		if err != nil {
+			log.Printf("error running open command: %v", err)
+		}
+	case "stop":
+		log.Printf("received stop command, shutting down")
+	case "paste":
+		contents, err := paste()
+		if err != nil {
+			s.logger.Printf("error running paste command: %v", err)
+		} else {
+			_, err := rw.Write(contents)
+			if err != nil {
+				s.logger.Printf("could not write paste message: %v", err)
+			}
+		}
+	default:
+		s.logger.Printf("command not found: %s", command.Name)
+	}
+}
+
+func (s *Server) Listen(ctx context.Context) error {
+	sock, err := net.Listen("unix", s.path)
+	if err != nil {
+		return fmt.Errorf("could not listen to unix socket: %w", err)
+	}
 	defer os.Remove(s.path)
 
-	connections := make(chan net.Conn)
+	ctx, cancel := context.WithCancel(ctx)
 
 	go func() {
-		for {
-			conn, err := sock.Accept()
-			if err != nil {
-				s.logger.Fatalf("could not accept connection: %v", err)
-				continue
-			}
-
-			connections <- conn
+		err = s.httpServer.Serve(sock)
+		if err != nil {
+			cancel()
 		}
 	}()
 
-	go func() {
-		for {
-			conn := <-connections
+	<-ctx.Done()
 
-			reader := bufio.NewReader(conn)
-			byteSize, err := reader.ReadBytes('\n')
-
-			if err != nil {
-				s.logger.Printf("Could not read size from conn")
-				continue
-			}
-
-			size, err := strconv.Atoi(string(byteSize[:len(byteSize)-1]))
-			if err != nil {
-				s.logger.Printf("Could not decode size from conn: %v", err)
-			}
-
-			content := make([]byte, size)
-			io.ReadFull(reader, content)
-
-			if err != nil {
-				s.logger.Printf("could not accept connection: %v", err)
-				continue
-			}
-
-			var command Command
-			json.Unmarshal(content, &command)
-
-			switch command.Name {
-			case "copy":
-				err := copy(command.Arguments[0])
-				if err != nil {
-					log.Printf("error running copy command: %v", err)
-				}
-			case "open":
-				err := open(command.Arguments[0])
-				if err != nil {
-					log.Printf("error running open command: %v", err)
-				}
-			case "stop":
-				log.Printf("received stop command, shutting down")
-				cancel()
-			case "paste":
-				contents, err := paste()
-				if err != nil {
-					s.logger.Printf("error running paste command: %v", err)
-				} else {
-					sizeMessage := fmt.Sprintf("%d\n", len(contents))
-					_, err = conn.Write([]byte(sizeMessage))
-					if err != nil {
-						s.logger.Printf("could not write paste size message: %v", err)
-					}
-
-					_, err := conn.Write(contents)
-					if err != nil {
-						s.logger.Printf("could not write paste message: %v", err)
-					}
-				}
-			default:
-				s.logger.Printf("command not found: %s", command.Name)
-			}
-
-			conn.Close()
-		}
-	}()
-
-	select {
-	case err := <-ctx.Done():
-		s.logger.Printf("Context cancelled: %v", err)
-	}
-
-	return nil
+	return ctx.Err()
 }
 
 func New(path string, logger *log.Logger) *Server {
-	return &Server{path: UnixSocketPath(), logger: logger}
+	server := &Server{path: UnixSocketPath(), logger: logger}
+	server.httpServer = &http.Server{
+		Handler:      server,
+		ReadTimeout:  time.Second * 10,
+		WriteTimeout: time.Second * 10,
+	}
+
+	return server
 }
 
 /// TODO extract into commands package and support more than macOS


### PR DESCRIPTION
Given how the initial spike turned out there wasn't much value using a
socket directly so this replaces the custom protocol with HTTP since
JSON is the message format either way.
