### PR TITLE
Make remote detection more reliable

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -59,7 +59,7 @@ const (
 func New() *Client {
 	runType := RunLocal
 
-	if os.Getenv("SSH_TTY") != "" {
+	if os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_CONNECTION") != "" {
 		runType = RunRemote
 	}
 


### PR DESCRIPTION
Sometimes `SSH_TTY` and `SSH_CLIENT` aren't set when in an ssh session,
so this checks three different potential environment variables that
indicate you're in a remote session.

* `SSH_TTY`
* `SSH_CLIENT`
* `SSH_CONNECTION`
