### PR TITLE
Properly support reading stdin

### DIFF
--- a/internal/cmd/copy_test.go
+++ b/internal/cmd/copy_test.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadBuffer(t *testing.T) {
+	testCases := map[string]struct {
+		value string
+	}{
+		"single line": {value: "foo"},
+		"multi-line":  {value: "foo\nbar\nbaz"},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			handle := strings.NewReader(tc.value)
+			reader := bufio.NewReader(handle)
+			content, err := readBuffer(reader)
+
+			require.NoError(t, err)
+			require.Equal(t, tc.value, content)
+		})
+	}
+}


### PR DESCRIPTION
Currently we read from stdin and always append a newline due to
`scanner.Scan` splitting on newlines. This isn't always correct, since
input doesn't always have a newline.

This resolves the issue by using `bufio.Reader.ReadBytes` which reads
up-to the delimiter and includes it, preserving newlines.

Fixes https://github.com/BlakeWilliams/remote-development-manager/issues/6
