### PR TITLE
Add custom commands

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,9 +2,13 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 
+	"github.com/blakewilliams/remote-development-manager/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -18,13 +22,45 @@ var LogPath string = os.TempDir() + "rdm.log"
 func Execute(ctx context.Context) error {
 	logger := log.Default()
 
-	rootCmd.AddCommand(newServerCmd(ctx, logger))
+	rdmConfig := config.New()
+
+	readConfig(rdmConfig)
+
+	rootCmd.AddCommand(newServerCmd(ctx, logger, rdmConfig))
 	rootCmd.AddCommand(newCopyCmd(ctx, logger))
 	rootCmd.AddCommand(newPasteCmd(ctx, logger))
 	rootCmd.AddCommand(newOpenCmd(ctx, logger))
 	rootCmd.AddCommand(newSocketCmd(ctx))
 	rootCmd.AddCommand(newStopCmd(ctx, logger))
 	rootCmd.AddCommand(newLogpathCmd(ctx))
+	rootCmd.AddCommand(newRunCmd(ctx, logger, rdmConfig))
+
+	if rdmConfig != nil {
+		rootCmd.AddCommand(newRunCmd(ctx, logger, rdmConfig))
+	}
 
 	return rootCmd.Execute()
+}
+
+func readConfig(rdmConfig *config.RdmConfig) {
+	home, err := os.UserHomeDir()
+	path := filepath.Join(home, ".config/rdm/rdm.json")
+
+	_, err = os.Stat(path)
+
+	if err != nil {
+		return
+	}
+
+	contents, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		panic(err)
+	}
+
+	err = json.Unmarshal(contents, rdmConfig)
+
+	if err != nil {
+		panic(err)
+	}
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/blakewilliams/remote-development-manager/internal/client"
+	"github.com/blakewilliams/remote-development-manager/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newRunCmd(ctx context.Context, logger *log.Logger, config *config.RdmConfig) *cobra.Command {
+	// TODO this needs to diverge, server should hold all the commands and
+	// client should query for available commands
+	return &cobra.Command{
+		Use:   "run",
+		Short: "Runs a custom command defined in the rdm config",
+		Long:  longRunDescription(config),
+		Run: func(cmd *cobra.Command, args []string) {
+			c := client.New()
+			content, err := c.SendCommand(context.TODO(), "run", args...)
+
+			if err != nil {
+				fmt.Printf("Could not run command: %v", err)
+				return
+			}
+
+			fmt.Println(string(content))
+		},
+	}
+}
+
+func longRunDescription(config *config.RdmConfig) string {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	var out strings.Builder
+
+	out.WriteString("Runs a custom command defined via rdm config\n\n")
+
+	c := client.New()
+	result, err := c.SendCommand(ctx, "commands")
+
+	if err != nil {
+		cancel()
+		out.WriteString("Could not communicate with server to get commands")
+		return out.String()
+	}
+
+	out.WriteString("Available commands:\n")
+
+	for _, command := range bytes.Split(result, []byte("\n")) {
+		out.WriteString("  ")
+		out.Write(command)
+	}
+
+	return out.String()
+}

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -6,11 +6,12 @@ import (
 	"os"
 
 	"github.com/blakewilliams/remote-development-manager/internal/clipboard"
+	"github.com/blakewilliams/remote-development-manager/internal/config"
 	"github.com/blakewilliams/remote-development-manager/internal/server"
 	"github.com/spf13/cobra"
 )
 
-func newServerCmd(ctx context.Context, logger *log.Logger) *cobra.Command {
+func newServerCmd(ctx context.Context, logger *log.Logger, rdmConfig *config.RdmConfig) *cobra.Command {
 	return &cobra.Command{
 		Use:   "server",
 		Short: "Starts a server on the local machine.",
@@ -25,7 +26,7 @@ func newServerCmd(ctx context.Context, logger *log.Logger) *cobra.Command {
 			defer logFile.Close()
 			log.SetOutput(logFile)
 
-			s := server.New(server.UnixSocketPath(), clipboard.MacosClipboard, logger)
+			s := server.New(server.UnixSocketPath(), clipboard.MacosClipboard, logger, rdmConfig)
 			err = s.Listen(ctx)
 
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,15 @@
+package config
+
+type (
+	RdmConfig struct {
+		Commands map[string]userCommand `json:"commands"`
+	}
+
+	userCommand struct {
+		ExecutablePath string `json:"executablePath"`
+	}
+)
+
+func New() *RdmConfig {
+	return &RdmConfig{Commands: map[string]userCommand{}}
+}

--- a/internal/server/process.go
+++ b/internal/server/process.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"os/exec"
+	"sync"
+)
+
+type processManager struct {
+	commands map[int]*exec.Cmd
+	mu       sync.Mutex
+}
+
+func (pm *processManager) Start(name string, path string, args ...string) error {
+	cmd := exec.Command(path, args...)
+	err := cmd.Start()
+
+	if err != nil {
+		return err
+	}
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	pid := cmd.Process.Pid
+	pm.commands[pid] = cmd
+
+	go func(cmd *exec.Cmd, pid int) {
+		cmd.Wait()
+
+		pm.mu.Lock()
+		defer pm.mu.Unlock()
+
+		if _, ok := pm.commands[cmd.Process.Pid]; ok {
+			delete(pm.commands, pid)
+		}
+
+	}(cmd, pid)
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -10,8 +10,6 @@ import (
 	"github.com/blakewilliams/remote-development-manager/internal/cmd"
 )
 
-var LogPath string = os.TempDir() + "rdm.log"
-
 func main() {
 	logger := log.Default()
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
* Adds custom commands that can be run from the client on the server
  process
* Adds process manager so processes can (eventually) be managed if they
  are marked as long running.

TO-DO:

* [ ] Add tests 
* [ ] Support long running commands (`rdm ps`, `rdm kill`)
