### PR TITLE
Delete socket file when server isn't running

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -65,6 +65,10 @@ const (
 )
 
 func New() *Client {
+	return NewWithSocketPath(UnixSocketPath())
+}
+
+func NewWithSocketPath(socketPath string) *Client {
 	runType := RunLocal
 
 	if os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CLIENT") != "" || os.Getenv("SSH_CONNECTION") != "" {
@@ -78,7 +82,7 @@ func New() *Client {
 	}
 
 	if runType == RunLocal {
-		client.path = "http://unix://" + UnixSocketPath()
+		client.path = "http://unix://" + socketPath
 	} else {
 		client.path = "http://localhost:7391"
 	}
@@ -86,7 +90,7 @@ func New() *Client {
 	if runType == RunLocal {
 		client.httpClient.Transport = &http.Transport{
 			DialContext: func(_ctx context.Context, _network string, _address string) (net.Conn, error) {
-				return net.Dial("unix", UnixSocketPath())
+				return net.Dial("unix", socketPath)
 			},
 		}
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,9 +9,8 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
-
-	"github.com/blakewilliams/remote-development-manager/internal/server"
 )
 
 type Client struct {
@@ -21,8 +20,17 @@ type Client struct {
 	httpClient http.Client
 }
 
+type Command struct {
+	Name      string
+	Arguments []string
+}
+
+func UnixSocketPath() string {
+	return strings.TrimRight(os.TempDir(), "/") + "/rdm.sock"
+}
+
 func (c *Client) SendCommand(ctx context.Context, commandName string, arguments ...string) ([]byte, error) {
-	command := server.Command{
+	command := Command{
 		Name:      commandName,
 		Arguments: arguments,
 	}
@@ -70,7 +78,7 @@ func New() *Client {
 	}
 
 	if runType == RunLocal {
-		client.path = "http://unix://" + server.UnixSocketPath()
+		client.path = "http://unix://" + UnixSocketPath()
 	} else {
 		client.path = "http://localhost:7391"
 	}
@@ -78,7 +86,7 @@ func New() *Client {
 	if runType == RunLocal {
 		client.httpClient.Transport = &http.Transport{
 			DialContext: func(_ctx context.Context, _network string, _address string) (net.Conn, error) {
-				return net.Dial("unix", server.UnixSocketPath())
+				return net.Dial("unix", UnixSocketPath())
 			},
 		}
 	}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/blakewilliams/remote-development-manager/internal/server"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,7 +29,7 @@ func TestClient_SendCommand(t *testing.T) {
 		content, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 
-		var command server.Command
+		var command Command
 		err = json.Unmarshal(content, &command)
 
 		require.NoError(t, err)

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 
+	"github.com/blakewilliams/remote-development-manager/internal/client"
 	"github.com/blakewilliams/remote-development-manager/internal/clipboard"
 	"github.com/blakewilliams/remote-development-manager/internal/server"
 	"github.com/spf13/cobra"
@@ -25,10 +27,11 @@ func newServerCmd(ctx context.Context, logger *log.Logger) *cobra.Command {
 			defer logFile.Close()
 			log.SetOutput(logFile)
 
-			s := server.New(server.UnixSocketPath(), clipboard.MacosClipboard, logger)
+			s := server.New(client.UnixSocketPath(), clipboard.MacosClipboard, logger)
 			err = s.Listen(ctx)
 
 			if err != nil {
+				fmt.Println(err)
 				log.Printf("Server could not be started: %v", err)
 				cancel()
 				return

--- a/internal/cmd/socket.go
+++ b/internal/cmd/socket.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/blakewilliams/remote-development-manager/internal/server"
+	"github.com/blakewilliams/remote-development-manager/internal/client"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +13,7 @@ func newSocketCmd(ctx context.Context) *cobra.Command {
 		Use:   "socket",
 		Short: "Prints the location of the unix socket",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(server.UnixSocketPath())
+			fmt.Println(client.UnixSocketPath())
 		},
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,7 +89,8 @@ func (s *Server) Listen(ctx context.Context) error {
 		var errNo syscall.Errno
 
 		if errors.As(err, &errNo) && errNo == syscall.EADDRINUSE {
-			c := client.New()
+			c := client.NewWithSocketPath(s.path)
+
 			_, err := c.SendCommand(ctx, "status")
 
 			if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -10,9 +11,10 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"strings"
+	"syscall"
 	"time"
 
+	"github.com/blakewilliams/remote-development-manager/internal/client"
 	"github.com/blakewilliams/remote-development-manager/internal/clipboard"
 )
 
@@ -24,15 +26,6 @@ type Server struct {
 	cancel     context.CancelFunc
 }
 
-type Command struct {
-	Name      string
-	Arguments []string
-}
-
-func UnixSocketPath() string {
-	return strings.TrimRight(os.TempDir(), "/") + "/rdm.sock"
-}
-
 func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -40,10 +33,12 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 	r.Body.Close()
 
-	var command Command
+	var command client.Command
 	json.Unmarshal(body, &command)
 
 	switch command.Name {
+	case "status":
+		rw.Write([]byte(`{ "status": "running" }`))
 	case "copy":
 		err := s.clipboard.Copy(command.Arguments[0])
 		if err != nil {
@@ -91,7 +86,19 @@ func (s *Server) Serve(ctx context.Context, listener net.Listener) error {
 func (s *Server) Listen(ctx context.Context) error {
 	sock, err := net.Listen("unix", s.path)
 	if err != nil {
-		return fmt.Errorf("could not listen to unix socket: %w", err)
+		var errNo syscall.Errno
+
+		if errors.As(err, &errNo) && errNo == syscall.EADDRINUSE {
+			c := client.New()
+			_, err := c.SendCommand(ctx, "status")
+
+			if err != nil {
+				os.Remove(s.path)
+				sock, err = net.Listen("unix", s.path)
+			} else {
+				return fmt.Errorf("could not listen to unix socket: %w", errNo)
+			}
+		}
 	}
 	defer os.Remove(s.path)
 


### PR DESCRIPTION
Sometimes the server dies without removing the socket file. When this
happens the server will fail to start even though there is no running
server.

Instead of failing immediately, the server command now attempts to talk
to the server running on the socket. If it succeeds, it exits since a
server is already running. If it fails, it removes the socket file and
starts the server.
