### PR TITLE
Add long help with link to repo

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,8 +9,10 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "rdm",
+	Use:   "remote-development-manager",
 	Short: "A server and client for better remote development integration.",
+	Long: `Embetter your remove development experience!
+	Complete documentation is available at https://github.com/BlakeWilliams/remote-development-manager`,
 }
 
 var LogPath string = os.TempDir() + "rdm.log"

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -9,9 +9,9 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "remote-development-manager",
+	Use:   "rdm",
 	Short: "A server and client for better remote development integration.",
-	Long: `Embetter your remove development experience!
+	Long: `Embetter your remote development experience!
 	Complete documentation is available at https://github.com/BlakeWilliams/remote-development-manager`,
 }
 


### PR DESCRIPTION
I thought this could use with a (brief) long help description and link back to the repo for the docs.

WDYT @BlakeWilliams ?