### PR TITLE
Prevent crash by ensuring LaunchAgents dir is created

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/blakewilliams/remote-development-manager
 go 1.17
 
 require (
-	github.com/brasic/launchd v1.0.1
+	github.com/brasic/launchd v1.0.3
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -64,12 +64,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
-github.com/brasic/launchd v0.2.8 h1:YJSZXSnz3LveGUOKPQJko7LI0K0SN37zjOWSrL7kyMs=
-github.com/brasic/launchd v0.2.8/go.mod h1:0W6FnIY9z3xNeg1vU2W2c6O4nY9macZqLEiJviCuOcU=
-github.com/brasic/launchd v1.0.0 h1:/lj8O0L2bA9GS8q7Eh80RqzN/BfjoInIVM2Qyyd0Dsg=
-github.com/brasic/launchd v1.0.0/go.mod h1:0W6FnIY9z3xNeg1vU2W2c6O4nY9macZqLEiJviCuOcU=
-github.com/brasic/launchd v1.0.1 h1:HC8d//CLrnwtIDwyyb7uXU6TIHg3zZb1uaGZEVJgnxw=
-github.com/brasic/launchd v1.0.1/go.mod h1:0W6FnIY9z3xNeg1vU2W2c6O4nY9macZqLEiJviCuOcU=
+github.com/brasic/launchd v1.0.3 h1:a5Y3nMCjiEMTkzXaNwIUm2U2ebZOickiu4NFGWPOTzE=
+github.com/brasic/launchd v1.0.3/go.mod h1:0W6FnIY9z3xNeg1vU2W2c6O4nY9macZqLEiJviCuOcU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=


### PR DESCRIPTION
I tried to use the launchd feature added in #16 on a new laptop but it didn't work:

```
$ rdm service
Manage this program as a launchd system service.
  Status of gui/502/me.blakewilliams.rdm:
    Install state: [Unknown] (Unexpected missing directory /Users/cbrasic/Library/LaunchAgents (stat /Users/cbrasic/Library/LaunchAgents: no such file or directory))
    Run state:     [NoSuchService]

Usage:
  rdm service [command]

Available Commands:
  install     Configures rdm to run on boot as a MacOS LaunchAgent.
  start       Starts the launchd service.
  stop        Stops the launchd service.
  uninstall   Removes a previously installed LaunchAgent installation.

Flags:
  -h, --help   help for service

Use "rdm service [command] --help" for more information about a command.
$ rdm service install
Problem installing: could not find definition path: Unexpected missing directory /Users/cbrasic/Library/LaunchAgents (stat /Users/cbrasic/Library/LaunchAgents: no such file or directory)
```

I neglected to always ensure the user LaunchAgents directory at `~/LaunchAgents` is present. That's fixed in https://github.com/brasic/launchd/pull/2 which this PR pulls in.