### PR TITLE
Add files to install via brew casks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,22 @@ specific.
 
 ## Installation
 
-The easiest way to install rdm is to [download the latest
+### Homebrew Casks:
+
+1. Tap the cask:
+   ```bash
+   brew tap BlakeWilliams/remote-development-manager
+   ```
+2. Install `rdm`:
+   ```bash
+   brew install --cask rdm
+   ```
+
+### Manual:
+
+[Download the latest
 release](https://github.com/BlakeWilliams/remote-development-manager/releases)
-for your platform. Alternatively, you can build it yourself with `go build main.go`.
+for your platform.
 
 e.g. for a Linux server you can use `wget` to download the binary then put it somewhere in your `$PATH`:
 
@@ -20,6 +33,10 @@ wget https://github.com/BlakeWilliams/remote-development-manager/releases/latest
 mv rdm-linux-amd64 /usr/local/bin/rdm
 chmod +x /usr/local/bin/rdm
 ```
+
+### Build from source:
+
+`go build main.go`.
 
 ### Mac daemon installation
 

--- a/homebrew/Casks/rdm.rb
+++ b/homebrew/Casks/rdm.rb
@@ -1,0 +1,30 @@
+cask "rdm" do
+  name "Remote Development Manager"
+  desc "A tool for remote development environments"
+  homepage "https://github.com/BlakeWilliams/remote-development-manager"
+  version "0.0.6"
+
+  file_to_move = if OS.mac?
+    if Hardware::CPU.arm?
+      url "https://github.com/BlakeWilliams/remote-development-manager/releases/download/v#{version}/rdm-darwin-arm64"
+      sha256 "c562d6040a2d84e60790f7de7a4bc7e4d9bdad390cc72cc0d402c7eb6e9553b2"
+      "rdm-darwin-arm64"
+    else
+      url "https://github.com/BlakeWilliams/remote-development-manager/releases/download/v#{version}/rdm-darwin-amd64"
+      sha256 "617d002120fdfe227aed377a998334ddbfc418758a03b89baa9027ea9f976429"
+      "rdm-darwin-amd64"
+    end
+  elsif OS.linux?
+    if Hardware::CPU.arm?
+      url "https://github.com/BlakeWilliams/remote-development-manager/releases/download/v#{version}/rdm-linux-arm64"
+      sha256 "fb42eacfe2ec272d66660569524ad4b732311727f31cb72d9ef8ea36bb852941"
+      "rdm-linux-arm64"
+    else
+      url "https://github.com/BlakeWilliams/remote-development-manager/releases/download/v#{version}/rdm-linux-amd64"
+      sha256 "9b79290ef87e0e0f37e71cf9a76ef1a4377472c56907fd01241f9881ecc57d36"
+      "rdm-linux-amd64"
+    end
+  end
+
+  binary file_to_move, target: "rdm"
+end


### PR DESCRIPTION

This PR adds a new cask for `rdm` (Remote Development Manager), a tool for managing remote development environments.

**Key Details:**
- Version: `0.0.6`
- Platforms: macOS (Intel and ARM), Linux (Intel and ARM)
- Dynamically selects the correct binary and architecture.
- Binaries hosted on the [official GitHub releases page](https://github.com/BlakeWilliams/remote-development-manager/releases).

**Verification:**
- Tested on macOS and Linux platforms.
- Binaries correctly linked using the `binary` stanza.

**Installation Instructions:**
```bash
brew tap BlakeWilliams/remote-development-manager
brew install --cask rdm
```