### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ specific.
 
 1. Tap the cask:
    ```bash
-   brew tap BlakeWilliams/remote-development-manager
+   brew tap BlakeWilliams/remote-development-manager https://github.com/BlakeWilliams/remote-development-manager
    ```
 2. Install `rdm`:
    ```bash


### PR DESCRIPTION
We need the url here otherwise `brew tap` looks in BlakeWilliams/homebrew-remote-development-manager for the homebrew cask code